### PR TITLE
Fixes #15. Serializing of non numbers (Float & Double)

### DIFF
--- a/src/main/java/metrics_influxdb/JsonBuilderDefault.java
+++ b/src/main/java/metrics_influxdb/JsonBuilderDefault.java
@@ -51,7 +51,16 @@ class JsonBuilderDefault implements JsonBuilder {
 					json.append('"').append(value).append('"');
 				} else if((value instanceof Collection) && ((Collection<?>)value).size()<1) {
 					json.append("null");
-				} else {
+				} 
+				else if (value instanceof Double && !Double.isFinite((double) value))
+				{
+					json.append("null");
+				}
+				else if (value instanceof Float && !Float.isFinite((float) value))
+				{
+					json.append("null");
+				}
+				else {
 					json.append(value);
 				}
 			}

--- a/src/test/java/sandbox/SendToLocalInfluxDB.java
+++ b/src/test/java/sandbox/SendToLocalInfluxDB.java
@@ -18,6 +18,7 @@ import metrics_influxdb.InfluxdbHttp;
 import metrics_influxdb.InfluxdbReporter;
 
 import com.codahale.metrics.ConsoleReporter;
+import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
@@ -32,6 +33,9 @@ public class SendToLocalInfluxDB {
       final MetricRegistry registry = new MetricRegistry();
       r0 = startConsoleReporter(registry);
       r1 = startInfluxdbReporter(registry);
+
+      registerGaugeWithValues(registry, "double", Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 1);
+      registerGaugeWithValues(registry, "float", Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY, 1);
 
       final Meter mymeter0 = registry.meter("MyMeter.0");
       for (int i = 0; i < 100; i++) {
@@ -55,8 +59,20 @@ public class SendToLocalInfluxDB {
     }
   }
 
-  private static InfluxdbReporter startInfluxdbReporter(MetricRegistry registry) throws Exception {
+  private static void registerGaugeWithValues(MetricRegistry registry, String prefix, Object ...values) {
+    for(final Object value : values) {
+      registry.register(prefix + value, new Gauge<Object>() {
+        @Override
+        public Object getValue() {
+          return value;
+        }
+       });
+    }
+  }
+
+private static InfluxdbReporter startInfluxdbReporter(MetricRegistry registry) throws Exception {
     final InfluxdbHttp influxdb = new InfluxdbHttp("127.0.0.1", 8086, "dev", "u0", "u0PWD");
+    //influxdb.debugJson = true;
     final InfluxdbReporter reporter = InfluxdbReporter
         .forRegistry(registry)
         .prefixedWith("test")


### PR DESCRIPTION
Serializing
Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY

as null.

This follows what's recommended by http://tools.ietf.org/html/rfc4627.

Influx will ignore these values when asked for the metrics.