### PR TITLE
Support Java 7 without sending NaN.

### DIFF
--- a/src/main/java/metrics_influxdb/JsonBuilderDefault.java
+++ b/src/main/java/metrics_influxdb/JsonBuilderDefault.java
@@ -52,11 +52,11 @@ class JsonBuilderDefault implements JsonBuilder {
 				} else if((value instanceof Collection) && ((Collection<?>)value).size()<1) {
 					json.append("null");
 				} 
-				else if (value instanceof Double && Double.isInfinite((double) value))
+				else if (value instanceof Double && (Double.isInfinite((double) value) || Double.isNaN((Double) value)))
 				{
 					json.append("null");
 				}
-				else if (value instanceof Float && Float.isInfinite((float) value))
+				else if (value instanceof Float && (Float.isInfinite((float) value) || Float.isNaN((Float) value)))
 				{
 					json.append("null");
 				}


### PR DESCRIPTION
A recent commit added a check for infinite numbers and NaN with a Java 8
API (Double.isfinite()). This was changed in a subsequent commit to a Java 7
API (Double.isInfinite()) but this does not check for NaN.

To support Java 7 and not send NaN an extra check using Double.isNaN() is
required.