### PR TITLE
Tag support for v08

### DIFF
--- a/src/main/java/metrics_influxdb/InfluxdbReporter.java
+++ b/src/main/java/metrics_influxdb/InfluxdbReporter.java
@@ -334,17 +334,17 @@ public class InfluxdbReporter extends SkipIdleReporter {
 	private final String prefix;
 	// Optimization : use pointsXxx to reduce object creation, by reuse as arg of
 	// Influxdb.appendSeries(...)
-	@VisibilityIncreasedForTests protected final Object[][] timerPoints;
-	@VisibilityIncreasedForTests protected final Object[][] histogramPoints;
-	@VisibilityIncreasedForTests protected final Object[][] countPoints;
-	@VisibilityIncreasedForTests protected final Object[][] gaugePoints;
-	@VisibilityIncreasedForTests protected final Object[][] meterPoints;
+	@VisibilityIncreasedForTests final Object[][] timerPoints;
+	@VisibilityIncreasedForTests final Object[][] histogramPoints;
+	@VisibilityIncreasedForTests final Object[][] countPoints;
+	@VisibilityIncreasedForTests final Object[][] gaugePoints;
+	@VisibilityIncreasedForTests final Object[][] meterPoints;
 
-	@VisibilityIncreasedForTests protected final String[] timerColumns;
-	@VisibilityIncreasedForTests protected final String[] histogramColumns;
-	@VisibilityIncreasedForTests protected final String[] countColumns;
-	@VisibilityIncreasedForTests protected final String[] gaugeColumns;
-	@VisibilityIncreasedForTests protected final String[] meterColumns;
+	@VisibilityIncreasedForTests final String[] timerColumns;
+	@VisibilityIncreasedForTests final String[] histogramColumns;
+	@VisibilityIncreasedForTests final String[] countColumns;
+	@VisibilityIncreasedForTests final String[] gaugeColumns;
+	@VisibilityIncreasedForTests final String[] meterColumns;
 
 	private InfluxdbReporter(
 			MetricRegistry registry,

--- a/src/test/java/metrics_influxdb/InfluxdbReporterBuilderTest.java
+++ b/src/test/java/metrics_influxdb/InfluxdbReporterBuilderTest.java
@@ -4,8 +4,10 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
 
@@ -58,14 +60,42 @@ public class InfluxdbReporterBuilderTest {
     
     @Test
     public void builder_api_with_compatibility_v08() {
+        String tag = "tag1";
+        String tagValue = "val1";
+
         Influxdb influxdbMock = Mockito.mock(Influxdb.class);
         ScheduledReporter reporter = 
                 InfluxdbReporter
                     .forRegistry(registry)
                     .v08(influxdbMock)
+                    .tag(tag, tagValue)
                     .build();
-        
+
         assertThat(reporter, notNullValue());
+        assertTrue(reporter instanceof InfluxdbReporter);
+
+        InfluxdbReporter influxReporter = (InfluxdbReporter) reporter;
+
+        // verify tags are added to the column arrays
+        assertEquals(influxReporter.timerColumns[influxReporter.timerColumns.length - 1], tag);
+        assertEquals(influxReporter.histogramColumns[influxReporter.histogramColumns.length - 1], tag);
+        assertEquals(influxReporter.countColumns[influxReporter.countColumns.length - 1], tag);
+        assertEquals(influxReporter.gaugeColumns[influxReporter.gaugeColumns.length - 1], tag);
+        assertEquals(influxReporter.meterColumns[influxReporter.meterColumns.length - 1], tag);
+
+        // verify tag values are added to the point arrays
+        assertEquals(influxReporter.timerPoints[0][influxReporter.timerPoints[0].length - 1], tagValue);
+        assertEquals(influxReporter.histogramPoints[0][influxReporter.histogramPoints[0].length - 1], tagValue);
+        assertEquals(influxReporter.countPoints[0][influxReporter.countPoints[0].length - 1], tagValue);
+        assertEquals(influxReporter.gaugePoints[0][influxReporter.gaugePoints[0].length - 1], tagValue);
+        assertEquals(influxReporter.meterPoints[0][influxReporter.meterPoints[0].length - 1], tagValue);
+
+        // verify that the arrays are still the same size
+        assertEquals(influxReporter.timerColumns.length, influxReporter.timerPoints[0].length);
+        assertEquals(influxReporter.histogramColumns.length, influxReporter.histogramPoints[0].length);
+        assertEquals(influxReporter.countColumns.length, influxReporter.countPoints[0].length);
+        assertEquals(influxReporter.gaugeColumns.length, influxReporter.gaugePoints[0].length);
+        assertEquals(influxReporter.meterColumns.length, influxReporter.meterPoints[0].length);
     }
 
     @Test


### PR DESCRIPTION
@davidB 

Adding support for `.tags()` when using `.v08()` in `InfluxdbReporter.Builder`. To accomplish this I had to change the column and point arrays to initialize with the tag info when instantiating an `InfluxdbReporter`.
