### PR TITLE
do not send NaN or infinite values (not supported by InfluxDB)

### DIFF
--- a/src/main/java/metrics_influxdb/measurements/Measure.java
+++ b/src/main/java/metrics_influxdb/measurements/Measure.java
@@ -196,7 +196,9 @@ public class Measure implements Measurement {
 		return addValue(key, Double.valueOf(value));
 	}
 	public Measure addValue(String key, double value) {
-		values.put(key, ""+value);
+		if (!((Double.isNaN(value)) || Double.isInfinite(value))) {
+			values.put(key, "" + value);
+		}
 		return this;
 	}
 	public Measure addValue(String key, int value) {

--- a/src/test/java/metrics_influxdb/measurements/MeasureTest.java
+++ b/src/test/java/metrics_influxdb/measurements/MeasureTest.java
@@ -1,0 +1,38 @@
+package metrics_influxdb.measurements;
+
+import static junit.framework.TestCase.assertTrue;
+
+import org.junit.Test;
+
+public class MeasureTest {
+
+		@Test
+		public void nanOrInfiniteValueSkippedTest() {
+
+				Measure m = new Measure("name");
+				m.addValue("one", 1.0);
+				assertTrue(m.getValues().size() == 1);
+
+				m.addValue("Float.NaN", Float.NaN);
+				assertTrue(m.getValues().size() == 1);
+
+				m.addValue("Float.NEGATIVE_INFINITY", Float.NEGATIVE_INFINITY);
+				assertTrue(m.getValues().size() == 1);
+
+				m.addValue("Float.POSITIVE_INFINITY", Float.POSITIVE_INFINITY);
+				assertTrue(m.getValues().size() == 1);
+
+				m.addValue("Double.NaN", Double.NaN);
+				assertTrue(m.getValues().size() == 1);
+
+				m.addValue("Double.NEGATIVE_INFINITY", Double.NEGATIVE_INFINITY);
+				assertTrue(m.getValues().size() == 1);
+
+				m.addValue("Double.POSITIVE_INFINITY", Double.POSITIVE_INFINITY);
+				assertTrue(m.getValues().size() == 1);
+
+				m.addValue("two", 2);
+				assertTrue(m.getValues().size() == 2);
+
+		}
+}


### PR DESCRIPTION
Nan values are not supported by influxdb and thus need to be skipped.

curl -i -XPOST 'http://localhost:8086/write?precision=ms&db=metrics' --data-binary 'cpu mean=NaN 1464880881814'
HTTP/1.1 400 Bad Request
Content-Type: application/json
Request-Id: 5901f72c-2e27-11e6-b798-000000000000
X-Influxdb-Version: 0.13.0
Date: Thu, 09 Jun 2016 09:48:41 GMT
Content-Length: 73

{"error":"unable to parse 'cpu mean=NaN 1464880881814': invalid number"}