### PR TITLE
Escape '=' character in addition to ' ' and ',' 

### DIFF
--- a/src/main/java/metrics_influxdb/misc/BoundedFIFO.java
+++ b/src/main/java/metrics_influxdb/misc/BoundedFIFO.java
@@ -11,14 +11,14 @@ public class BoundedFIFO<T> implements Queue<T> {
 
 	public BoundedFIFO(int capacity) {
 		this.delegate = new LinkedBlockingQueue<>(capacity);
-	}
+	} 
 
 	public int hashCode() {
 		return delegate.hashCode();
 	}
 
 	public boolean add(T e) {
-		while (!delegate.offer(e)) {
+		while (!delegate.add(e)) {
 			delegate.poll();
 		}
 		return true;

--- a/src/main/java/metrics_influxdb/misc/BoundedFIFO.java
+++ b/src/main/java/metrics_influxdb/misc/BoundedFIFO.java
@@ -11,14 +11,14 @@ public class BoundedFIFO<T> implements Queue<T> {
 
 	public BoundedFIFO(int capacity) {
 		this.delegate = new LinkedBlockingQueue<>(capacity);
-	} 
+	}
 
 	public int hashCode() {
 		return delegate.hashCode();
 	}
 
 	public boolean add(T e) {
-		while (!delegate.add(e)) {
+		while (!delegate.offer(e)) {
 			delegate.poll();
 		}
 		return true;

--- a/src/main/java/metrics_influxdb/serialization/line/Inliner.java
+++ b/src/main/java/metrics_influxdb/serialization/line/Inliner.java
@@ -6,7 +6,9 @@ import metrics_influxdb.measurements.Measure;
 import metrics_influxdb.misc.Miscellaneous;
 
 public class Inliner {
-	public String inline(Measure m) {
+  private static char[] ESCAPE_CHARS = {' ', ',', '='};
+
+  public String inline(Measure m) {
 		String key = buildMeasureKey(m.getName(), m.getTags());
 		String values = buildMeasureFields(m.getValues());
 		String timestamp = "" + m.getTimestamp();
@@ -33,19 +35,19 @@ public class Inliner {
 		String join = "";
 
 		for (Map.Entry<String, String> v: sortedValues.entrySet()) {
-			fields.append(join).append(Miscellaneous.escape(v.getKey(), ' ', ',')).append("=").append(v.getValue());		// values are already escaped
+			fields.append(join).append(Miscellaneous.escape(v.getKey(), ESCAPE_CHARS)).append("=").append(v.getValue());		// values are already escaped
 			join = ",";
 		}
 		return fields.toString();
 	}
 
 	private String buildMeasureKey(String name, Map<String, String> tags) {
-		StringBuilder key = new StringBuilder(Miscellaneous.escape(name, ' ', ','));
+		StringBuilder key = new StringBuilder(Miscellaneous.escape(name, ESCAPE_CHARS));
 		Map<String, String> sortedTags = new InfluxDBSortedMap();
 		sortedTags.putAll(tags);
 
 		for (Map.Entry<String, String> e: sortedTags.entrySet()) {
-			key.append(',').append(Miscellaneous.escape(e.getKey(), ' ', ',')).append("=").append(Miscellaneous.escape(e.getValue(), ' ', ','));
+			key.append(',').append(Miscellaneous.escape(e.getKey(), ESCAPE_CHARS)).append("=").append(Miscellaneous.escape(e.getValue(), ESCAPE_CHARS));
 		}
 
 		return key.toString();

--- a/src/test/java/metrics_influxdb/measurements/MeasureTest.java
+++ b/src/test/java/metrics_influxdb/measurements/MeasureTest.java
@@ -1,8 +1,9 @@
 package metrics_influxdb.measurements;
 
-import static junit.framework.TestCase.assertTrue;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertTrue;
 
 public class MeasureTest {
 


### PR DESCRIPTION
Thanks for the great metrics reporter.  I ran into issues though when metrics or tags contain '=' character.  These also need to be escaped.