### PR TITLE
UDP Protocol should send timestamps of the correct precision

### DIFF
--- a/src/main/java/metrics_influxdb/measurements/HttpInlinerSender.java
+++ b/src/main/java/metrics_influxdb/measurements/HttpInlinerSender.java
@@ -26,7 +26,7 @@ public class HttpInlinerSender extends QueueableSender {
 		super(MAX_MEASURES_IN_SINGLE_POST);
 		URL toJoin;
 
-		inliner = new Inliner();
+		inliner = new Inliner(TimeUnit.MILLISECONDS);
 
 		try {
 			if (protocol.secured) {

--- a/src/main/java/metrics_influxdb/measurements/UDPInlinerSender.java
+++ b/src/main/java/metrics_influxdb/measurements/UDPInlinerSender.java
@@ -6,6 +6,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,7 +23,7 @@ public class UDPInlinerSender extends QueueableSender {
 
 	public UDPInlinerSender(UDPInfluxdbProtocol protocol) {
 		super(MAX_MEASURES_IN_SINGLE_POST);
-		inliner = new Inliner();
+		inliner = new Inliner(TimeUnit.NANOSECONDS);
 		serverAddress = new InetSocketAddress(protocol.host, protocol.port);
 	}
 

--- a/src/main/java/metrics_influxdb/serialization/line/Inliner.java
+++ b/src/main/java/metrics_influxdb/serialization/line/Inliner.java
@@ -1,15 +1,22 @@
 package metrics_influxdb.serialization.line;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import metrics_influxdb.measurements.Measure;
 import metrics_influxdb.misc.Miscellaneous;
 
 public class Inliner {
-	public String inline(Measure m) {
+		private TimeUnit precision;
+
+		public Inliner(TimeUnit precision) {
+			this.precision = precision;
+		}
+
+		public String inline(Measure m) {
 		String key = buildMeasureKey(m.getName(), m.getTags());
 		String values = buildMeasureFields(m.getValues());
-		String timestamp = "" + m.getTimestamp();
+		String timestamp = "" + precision.convert(m.getTimestamp(), TimeUnit.MILLISECONDS);
 
 		return key + " " + values +  " " + timestamp;
 	}

--- a/src/test/java/metrics_influxdb/measurements/ListInlinerSender.java
+++ b/src/test/java/metrics_influxdb/measurements/ListInlinerSender.java
@@ -3,6 +3,7 @@ package metrics_influxdb.measurements;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import metrics_influxdb.serialization.line.Inliner;
 
@@ -12,7 +13,7 @@ public class ListInlinerSender extends QueueableSender {
 
 	public ListInlinerSender(int queueSize) {
 		super(queueSize);
-		inliner = new Inliner();
+		inliner = new Inliner(TimeUnit.MILLISECONDS);
 		frames = new LinkedList<>();
 	}
 

--- a/src/test/java/metrics_influxdb/measurements/MeasureTest.java
+++ b/src/test/java/metrics_influxdb/measurements/MeasureTest.java
@@ -1,8 +1,8 @@
 package metrics_influxdb.measurements;
 
-import static junit.framework.TestCase.assertTrue;
+import static org.testng.Assert.assertTrue;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class MeasureTest {
 

--- a/src/test/java/metrics_influxdb/serialization/line/InlinerTest.java
+++ b/src/test/java/metrics_influxdb/serialization/line/InlinerTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -17,10 +18,9 @@ import static org.testng.AssertJUnit.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import metrics_influxdb.measurements.Measure;
-import metrics_influxdb.serialization.line.Inliner;
 
 public class InlinerTest {
-	private Inliner inliner = new Inliner();
+	private Inliner inliner = new Inliner(TimeUnit.MILLISECONDS);
 
 	@Test
 	public void a_single_word_name_is_untouched() {
@@ -140,6 +140,17 @@ public class InlinerTest {
 		String output = inliner.inline(m);
 
 		assertThat(output, endsWith(""+time));
+	}
+
+	@Test
+	public void given_timestamp_with_precision_is_used() {
+		inliner = new Inliner(TimeUnit.NANOSECONDS);
+		long time = System.currentTimeMillis();
+		Measure m = new Measure("cpu", 0l, time);
+
+		String output = inliner.inline(m);
+
+		assertThat(output, endsWith(""+time + "000000"));
 	}
 
 	@Test


### PR DESCRIPTION
..when accepting measurements via UDP InfluxDB expects timestamps to be in NANOSECOND format, but the inliner keeps them as MILLISECOND format.  This causes the occasional issue :/

Seeing as the HTTP Protocol sends precision=ms, and the timestamps are in ms anyway, I've added the ability for the inliner to convert to an arbitrary precision when it's called