### PR TITLE
add MetricsAdapter capability

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -63,3 +63,6 @@ brace_style = expand
 ;vim:path=~/.vim/bundle/js-beautify/js/lib/beautify-html.js
 ;vim:max_char=78:brace_style=expand
 
+[**.java]
+indent_size = 2
+indent_style = tab

--- a/src/main/java/metrics_influxdb/InfluxdbReporter.java
+++ b/src/main/java/metrics_influxdb/InfluxdbReporter.java
@@ -24,6 +24,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
 
 import metrics_influxdb.api.measurements.MetricMeasurementTransformer;
+import metrics_influxdb.api.measurements.MetricsAdapter;
 import metrics_influxdb.measurements.HttpInlinerSender;
 import metrics_influxdb.measurements.MeasurementReporter;
 import metrics_influxdb.measurements.Sender;
@@ -39,9 +40,9 @@ import metrics_influxdb.v08.ReporterV08;
  * A reporter which publishes metric values to a InfluxDB server.
  *
  * @see <a href="http://influxdb.org/">InfluxDB - An open-source distributed
- *      time series database with no external dependencies.</a>
+ * time series database with no external dependencies.</a>
  */
-public class InfluxdbReporter  {
+public class InfluxdbReporter {
 
 	static enum InfluxdbCompatibilityVersions {
 		V08, LATEST;
@@ -50,8 +51,7 @@ public class InfluxdbReporter  {
 	/**
 	 * Returns a new {@link Builder} for {@link InfluxdbReporter}.
 	 *
-	 * @param registry
-	 *          the registry to report
+	 * @param registry the registry to report
 	 * @return a {@link Builder} instance for a {@link InfluxdbReporter}
 	 */
 	public static Builder forRegistry(MetricRegistry registry) {
@@ -79,6 +79,7 @@ public class InfluxdbReporter  {
 		@VisibilityIncreasedForTests Influxdb influxdbDelegate;
 		@VisibilityIncreasedForTests Map<String, String> tags;
 		@VisibilityIncreasedForTests MetricMeasurementTransformer transformer = MetricMeasurementTransformer.NOOP;
+		@VisibilityIncreasedForTests MetricsAdapter adapter = MetricsAdapter.NOOP;
 
 		private Builder(MetricRegistry registry) {
 			this.registry = registry;
@@ -183,15 +184,15 @@ public class InfluxdbReporter  {
 			default:
 				Sender s = buildSender();
 				reporter = executor == null
-						? new MeasurementReporter(s, registry, filter, rateUnit, durationUnit, clock, tags, transformer)
-						: new MeasurementReporter(s, registry, filter, rateUnit, durationUnit, clock, tags, transformer, executor)
+						? new MeasurementReporter(s, registry, filter, rateUnit, durationUnit, clock, tags, transformer, adapter)
+						: new MeasurementReporter(s, registry, filter, rateUnit, durationUnit, clock, tags, transformer, adapter, executor)
 						;
 			}
 			return reporter;
 		}
 
 		/**
-		 * Operates with influxdb version less or equal than 08. 
+		 * Operates with influxdb version less or equal than 08.
 		 * @return the builder itself
 		 */
 		public Builder v08() {
@@ -233,14 +234,25 @@ public class InfluxdbReporter  {
 			return this;
 		}
 
+		/**
+		 * Registers an adapter for the measurements.
+		 * @param adapter the adapter object
+		 * @return
+		 */
+		public Builder adapter(MetricsAdapter adapter) {
+			Objects.requireNonNull(adapter, "given MetricsAdapter cannot be null");
+			this.adapter = adapter;
+			return this;
+		}
+
 		private Influxdb buildInfluxdb() {
 			if (protocol instanceof HttpInfluxdbProtocol) {
 				try {
 					HttpInfluxdbProtocol p = (HttpInfluxdbProtocol) protocol;
 					return new InfluxdbHttp(p.scheme, p.host, p.port, p.database, p.user, p.password, durationUnit);
-				} catch(RuntimeException exc) {
+				} catch (RuntimeException exc) {
 					throw exc;
-				} catch(Exception exc) {
+				} catch (Exception exc) {
 					// wrap exception into RuntimeException
 					throw new RuntimeException(exc.getMessage(), exc);
 				}

--- a/src/main/java/metrics_influxdb/api/measurements/MetricsAdapter.java
+++ b/src/main/java/metrics_influxdb/api/measurements/MetricsAdapter.java
@@ -1,0 +1,26 @@
+package metrics_influxdb.api.measurements;
+
+import com.codahale.metrics.Metric;
+import metrics_influxdb.measurements.Measure;
+
+/**
+ * Interface to adapt measurements reported before they are sent out.
+ */
+public interface MetricsAdapter {
+
+	/**
+	 * @param name    name of the metric
+	 * @param metric  the metric to adapt
+	 * @param measure measure object (warning, this can and typically will be changed by implementations)
+	 * @return returns adapted measure object (can be the same one that was passed in)
+	 */
+	Measure adapt(String name, Metric metric, Measure measure);
+
+	MetricsAdapter NOOP = new MetricsAdapter() {
+		@Override
+		public Measure adapt(String name, Metric metric, Measure measure) {
+			return measure;
+		}
+	};
+
+}

--- a/src/main/java/metrics_influxdb/api/measurements/RelativeCounterMetricsAdapter.java
+++ b/src/main/java/metrics_influxdb/api/measurements/RelativeCounterMetricsAdapter.java
@@ -1,0 +1,39 @@
+package metrics_influxdb.api.measurements;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Metric;
+import metrics_influxdb.measurements.Measure;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Paul Klingelhuber
+ */
+public class RelativeCounterMetricsAdapter implements MetricsAdapter {
+
+  private final Map<String, Long> previousCounts = new HashMap<>();
+
+  @Override
+  public Measure adapt(String name, Metric metric, Measure measure) {
+    if (metric instanceof Counter) {
+      final Counter counter = (Counter) metric;
+      final long count = counter.getCount();
+      long previous = getPreviousCountAndSaveCurrent(name, count);
+      // add count again to overwrite any previously set one (could have changed in the meantime)
+      measure.addValue("count", count);
+      measure.addValue("relativeCount", count - previous);
+    }
+    return measure;
+  }
+
+  private long getPreviousCountAndSaveCurrent(String name, long count) {
+    final Long previous = previousCounts.get(name);
+    previousCounts.put(name, count);
+    if (previous == null) {
+      return 0;
+    }
+    return previous;
+  }
+
+}

--- a/src/test/java/metrics_influxdb/api/measurements/RelativeCounterMetricsAdapterTest.java
+++ b/src/test/java/metrics_influxdb/api/measurements/RelativeCounterMetricsAdapterTest.java
@@ -1,0 +1,28 @@
+package metrics_influxdb.api.measurements;
+
+import com.codahale.metrics.Counter;
+import metrics_influxdb.measurements.Measure;
+import org.junit.Test;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class RelativeCounterMetricsAdapterTest {
+
+	@Test
+	public void test() {
+		RelativeCounterMetricsAdapter relativeCounterMetricsAdapter = new RelativeCounterMetricsAdapter();
+		Counter counter = new Counter();
+		counter.inc(999);
+		final Measure first = relativeCounterMetricsAdapter.adapt("test", counter, new Measure("test"));
+
+		assertThat(first.getValues().get("count")).isEqualTo("999i");
+		assertThat(first.getValues().get("relativeCount")).isEqualTo("999i");
+
+		counter.inc();
+		Measure second = relativeCounterMetricsAdapter.adapt("test", counter, new Measure("test"));
+
+		assertThat(second.getValues().get("count")).isEqualTo("1000i");
+		assertThat(second.getValues().get("relativeCount")).isEqualTo("1i");
+	}
+
+}

--- a/src/test/java/metrics_influxdb/measurements/MeasurementReporterTest.java
+++ b/src/test/java/metrics_influxdb/measurements/MeasurementReporterTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.*;
 import com.codahale.metrics.Timer.Context;
 import metrics_influxdb.SortedMaps;
 import metrics_influxdb.api.measurements.MetricMeasurementTransformer;
+import metrics_influxdb.api.measurements.MetricsAdapter;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -25,7 +26,7 @@ public class MeasurementReporterTest {
 	public void init() {
 		sender = new ListInlinerSender(100);
 		registry = new MetricRegistry();
-		reporter = new MeasurementReporter(sender, registry, null, TimeUnit.SECONDS, TimeUnit.MILLISECONDS, Clock.defaultClock(), Collections.<String, String>emptyMap(), MetricMeasurementTransformer.NOOP);
+		reporter = new MeasurementReporter(sender, registry, null, TimeUnit.SECONDS, TimeUnit.MILLISECONDS, Clock.defaultClock(), Collections.<String, String>emptyMap(), MetricMeasurementTransformer.NOOP, MetricsAdapter.NOOP);
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/src/test/java/metrics_influxdb/measurements/MeasurementReporterWithBaseTagsTest.java
+++ b/src/test/java/metrics_influxdb/measurements/MeasurementReporterWithBaseTagsTest.java
@@ -3,6 +3,7 @@ package metrics_influxdb.measurements;
 import com.codahale.metrics.*;
 import metrics_influxdb.SortedMaps;
 import metrics_influxdb.api.measurements.MetricMeasurementTransformer;
+import metrics_influxdb.api.measurements.MetricsAdapter;
 import org.testng.annotations.Test;
 
 import java.util.HashMap;
@@ -27,7 +28,7 @@ public class MeasurementReporterWithBaseTagsTest {
 		Map<String, String> baseTags = new HashMap<>();
 		baseTags.put(serverKey, serverName);
 
-		MeasurementReporter reporter = new MeasurementReporter(sender, registry, null, TimeUnit.SECONDS, TimeUnit.MILLISECONDS, Clock.defaultClock(), baseTags, MetricMeasurementTransformer.NOOP);
+		MeasurementReporter reporter = new MeasurementReporter(sender, registry, null, TimeUnit.SECONDS, TimeUnit.MILLISECONDS, Clock.defaultClock(), baseTags, MetricMeasurementTransformer.NOOP, MetricsAdapter.NOOP);
 		assertThat(sender.getFrames().size(), is(0));
 
 		// Let's test with one counter


### PR DESCRIPTION
To process counter values in influxdb it's often easier to have the relative values (how much it changed since the last time) directly in the data, without having to extract that in an additional step in the db. This especially helps with counter changes in case of server restarts (where the counter resets).