### PR TITLE
Support different seperator for the key/values

### DIFF
--- a/src/main/java/metrics_influxdb/api/measurements/KeyValueMetricMeasurementTransformer.java
+++ b/src/main/java/metrics_influxdb/api/measurements/KeyValueMetricMeasurementTransformer.java
@@ -19,15 +19,25 @@ import java.util.Map;
  *  </ul>
  */
 public class KeyValueMetricMeasurementTransformer implements MetricMeasurementTransformer {
-	private final static String SEPARATOR = "\\.";
+	private final String seperator;
 
 	public KeyValueMetricMeasurementTransformer() {
+		this(null);
 	}
+	
+	public KeyValueMetricMeasurementTransformer(String customSeperatorRegex) {
+		if(customSeperatorRegex != null) {
+		    this.seperator = customSeperatorRegex;
+		}
+		else {
+		    this.seperator = "\\.";
+		}
+	    }
 
 	@Override
 	public Map<String, String> tags(String metricName) {
 		Map<String, String> generatedTags = new HashMap<>();
-		String[] splitted = metricName.split(SEPARATOR);
+		String[] splitted = metricName.split(seperator);
 
 		int nbPairs = isEven(splitted.length)?(splitted.length-1)/2:(splitted.length/2)-1;
 
@@ -44,7 +54,7 @@ public class KeyValueMetricMeasurementTransformer implements MetricMeasurementTr
 
 	@Override
 	public String measurementName(String metricName) {
-		String[] splitted = metricName.split(SEPARATOR);
+		String[] splitted = metricName.split(seperator);
 
 		if (isEven(splitted.length)) {
 			return splitted[splitted.length - 1];


### PR DESCRIPTION
I have a case in my system, that I need to define a measurement with dots in its name, and there should be more that 2 dots.
Moreover, I need to define dynamic tags in the influx DB per Metric, and the only way to do this in this framework, is to use the transformer.
So, in order to do so, I found that the easiest way is to have option to configure the separator in the KeyValueMetricMeasurementTransformer, so it won't be just dot.