### PR TITLE
Make HTTP connect timeout and read timeout configurable

### DIFF
--- a/src/main/java/metrics_influxdb/HttpInfluxdbProtocol.java
+++ b/src/main/java/metrics_influxdb/HttpInfluxdbProtocol.java
@@ -4,7 +4,9 @@ public class HttpInfluxdbProtocol implements InfluxdbProtocol {
 	public final static String DEFAULT_HOST = "127.0.0.1";
 	public final static int DEFAULT_PORT = 8086;
 	public final static String DEFAULT_DATABASE = "metrics";
-
+    public final static long DEFAULT_CONNECT_TIMEOUT_SECONDS = 2;
+    public final static long DEFAULT_READ_TIMEOUT_SECONDS = 2;
+    
 	public final String scheme;
 	public final String user;
 	public final String password;
@@ -12,8 +14,10 @@ public class HttpInfluxdbProtocol implements InfluxdbProtocol {
 	public final int port;
 	public final boolean secured;
 	public final String database;
+	public final long connectTimeout;
+	public final long readTimeout;
 
-	public HttpInfluxdbProtocol(String scheme, String host, int port, String user, String password, String db) {
+	public HttpInfluxdbProtocol(String scheme, String host, int port, String user, String password, String db, long connectTimeout, long readTimeout) {
 		super();
 		this.scheme = scheme;
 		this.host = host;
@@ -22,6 +26,12 @@ public class HttpInfluxdbProtocol implements InfluxdbProtocol {
 		this.password = password;
 		this.database = db;
 		this.secured = (user != null) && (password != null);
+		this.connectTimeout = connectTimeout;
+		this.readTimeout = readTimeout;
+	}
+	
+	public HttpInfluxdbProtocol(String scheme, String host, int port, String user, String password, String db) {
+	    this(scheme, host, port, user, password, db, DEFAULT_CONNECT_TIMEOUT_SECONDS, DEFAULT_READ_TIMEOUT_SECONDS);
 	}
 	
 	public HttpInfluxdbProtocol(String host, int port, String user, String password, String db) {

--- a/src/main/java/metrics_influxdb/HttpInfluxdbProtocol.java
+++ b/src/main/java/metrics_influxdb/HttpInfluxdbProtocol.java
@@ -4,8 +4,8 @@ public class HttpInfluxdbProtocol implements InfluxdbProtocol {
 	public final static String DEFAULT_HOST = "127.0.0.1";
 	public final static int DEFAULT_PORT = 8086;
 	public final static String DEFAULT_DATABASE = "metrics";
-    public final static long DEFAULT_CONNECT_TIMEOUT_SECONDS = 2;
-    public final static long DEFAULT_READ_TIMEOUT_SECONDS = 2;
+	public final static long DEFAULT_CONNECT_TIMEOUT_SECONDS = 2;
+	public final static long DEFAULT_READ_TIMEOUT_SECONDS = 2;
     
 	public final String scheme;
 	public final String user;

--- a/src/main/java/metrics_influxdb/measurements/HttpInlinerSender.java
+++ b/src/main/java/metrics_influxdb/measurements/HttpInlinerSender.java
@@ -21,12 +21,16 @@ public class HttpInlinerSender extends QueueableSender {
 	private static int MAX_MEASURES_IN_SINGLE_POST = 5000;
 	private final URL writeURL;
 	private final Inliner inliner;
+	private final long connectTimeout;
+	private final long readTimeout;
 
 	public HttpInlinerSender(HttpInfluxdbProtocol protocol) {
 		super(MAX_MEASURES_IN_SINGLE_POST);
 		URL toJoin;
 
 		inliner = new Inliner(TimeUnit.MILLISECONDS);
+		connectTimeout =  protocol.connectTimeout;
+		readTimeout = protocol.readTimeout;
 
 		try {
 			if (protocol.secured) {
@@ -52,8 +56,8 @@ public class HttpInlinerSender extends QueueableSender {
 		try {
 			con = (HttpURLConnection) writeURL.openConnection();
 			con.setRequestMethod("POST");
-			con.setConnectTimeout(Long.valueOf(TimeUnit.SECONDS.toMillis(2)).intValue());
-			con.setReadTimeout(Long.valueOf(TimeUnit.SECONDS.toMillis(2)).intValue());
+			con.setConnectTimeout(Long.valueOf(TimeUnit.SECONDS.toMillis(connectTimeout)).intValue());
+			con.setReadTimeout(Long.valueOf(TimeUnit.SECONDS.toMillis(readTimeout)).intValue());
 
 			// Send post request
 			con.setDoOutput(true);


### PR DESCRIPTION
Making HTTP connect timeout and read timeout configurable to reduce occasional SocketTimeoutExceptions thrown while using this reporter.